### PR TITLE
refactor: move entity to core domain

### DIFF
--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -37,7 +37,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/entity.Customer"
+                            "$ref": "#/definitions/domain.Customer"
                         }
                     },
                     "401": {
@@ -106,7 +106,7 @@
                                 "data": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/definitions/entity.AccrualRequest"
+                                        "$ref": "#/definitions/domain.AccrualRequest"
                                     }
                                 },
                                 "total": {
@@ -235,7 +235,7 @@
                                 "data": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/definitions/entity.AccrualRequest"
+                                        "$ref": "#/definitions/domain.AccrualRequest"
                                     }
                                 },
                                 "total": {
@@ -418,7 +418,7 @@
                                 "data": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/definitions/entity.MilesLedger"
+                                        "$ref": "#/definitions/domain.MilesLedger"
                                     }
                                 },
                                 "total": {
@@ -481,7 +481,7 @@
                                 "data": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/definitions/entity.MilesLedger"
+                                        "$ref": "#/definitions/domain.MilesLedger"
                                     }
                                 },
                                 "total": {
@@ -571,7 +571,7 @@
                 }
             }
         },
-        "entity.AccrualRequest": {
+        "domain.AccrualRequest": {
             "type": "object",
             "properties": {
                 "boarding_pass_image_url": {
@@ -646,7 +646,7 @@
                 }
             }
         },
-        "entity.Customer": {
+        "domain.Customer": {
             "type": "object",
             "properties": {
                 "auth0_user_id": {
@@ -686,7 +686,7 @@
                 }
             }
         },
-        "entity.MilesLedger": {
+        "domain.MilesLedger": {
             "type": "object",
             "properties": {
                 "accrual_request_id": {

--- a/api/internal/core/domain/customer.go
+++ b/api/internal/core/domain/customer.go
@@ -1,4 +1,4 @@
-package entity
+package domain
 
 import (
 	"time"

--- a/api/internal/core/domain/membership_history.go
+++ b/api/internal/core/domain/membership_history.go
@@ -1,4 +1,4 @@
-package entity
+package domain
 
 import (
 	"time"

--- a/api/internal/core/domain/mileage_accrual_request.go
+++ b/api/internal/core/domain/mileage_accrual_request.go
@@ -1,4 +1,4 @@
-package entity
+package domain
 
 import (
 	"time"

--- a/api/internal/core/domain/miles_ledger.go
+++ b/api/internal/core/domain/miles_ledger.go
@@ -1,4 +1,4 @@
-package entity
+package domain
 
 import (
 	"time"

--- a/api/internal/core/domain/travel_distance.go
+++ b/api/internal/core/domain/travel_distance.go
@@ -1,4 +1,4 @@
-package entity
+package domain
 
 import (
 	"time"

--- a/api/internal/repository/customer/repository.go
+++ b/api/internal/repository/customer/repository.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"errors"
 
-	"github.com/erwin-lovecraft/aegismiles/internal/entity"
+	"github.com/erwin-lovecraft/aegismiles/internal/core/domain"
 	"github.com/erwin-lovecraft/aegismiles/internal/pkg/generator"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
 type Repository interface {
-	Save(ctx context.Context, customer entity.Customer) error
+	Save(ctx context.Context, customer domain.Customer) error
 
-	GetByUserID(ctx context.Context, userID string) (entity.Customer, error)
+	GetByUserID(ctx context.Context, userID string) (domain.Customer, error)
 
-	GetByID(ctx context.Context, customerID string) (entity.Customer, error)
+	GetByID(ctx context.Context, customerID string) (domain.Customer, error)
 }
 
 type repository struct {
@@ -26,7 +26,7 @@ func NewRepository(db *gorm.DB) Repository {
 	return repository{db: db}
 }
 
-func (r repository) Save(ctx context.Context, customer entity.Customer) error {
+func (r repository) Save(ctx context.Context, customer domain.Customer) error {
 	if customer.ID == uuid.Nil {
 		customerID, err := generator.CustomerID.Generate()
 		if err != nil {
@@ -38,24 +38,24 @@ func (r repository) Save(ctx context.Context, customer entity.Customer) error {
 	return r.db.WithContext(ctx).Save(&customer).Error
 }
 
-func (r repository) GetByUserID(ctx context.Context, userID string) (entity.Customer, error) {
-	var customer entity.Customer
+func (r repository) GetByUserID(ctx context.Context, userID string) (domain.Customer, error) {
+	var customer domain.Customer
 	if err := r.db.WithContext(ctx).Where("auth0_user_id = ?", userID).First(&customer).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return entity.Customer{}, nil
+			return domain.Customer{}, nil
 		}
-		return entity.Customer{}, err
+		return domain.Customer{}, err
 	}
 	return customer, nil
 }
 
-func (r repository) GetByID(ctx context.Context, customerID string) (entity.Customer, error) {
-	var customer entity.Customer
+func (r repository) GetByID(ctx context.Context, customerID string) (domain.Customer, error) {
+	var customer domain.Customer
 	if err := r.db.WithContext(ctx).Where("id = ?", customerID).First(&customer).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return entity.Customer{}, nil
+			return domain.Customer{}, nil
 		}
-		return entity.Customer{}, err
+		return domain.Customer{}, err
 	}
 	return customer, nil
 }

--- a/api/internal/repository/membership/repository.go
+++ b/api/internal/repository/membership/repository.go
@@ -3,7 +3,7 @@ package membership
 import (
 	"context"
 
-	"github.com/erwin-lovecraft/aegismiles/internal/entity"
+	"github.com/erwin-lovecraft/aegismiles/internal/core/domain"
 	"gorm.io/gorm"
 )
 
@@ -12,9 +12,9 @@ type Repository interface {
 
 	UpdateCustomerMembershipTier(ctx context.Context, customerID string, memberTier string) error
 
-	GetCustomerByID(ctx context.Context, customerID string) (entity.Customer, error)
+	GetCustomerByID(ctx context.Context, customerID string) (domain.Customer, error)
 
-	SaveMembershipHistory(ctx context.Context, history entity.MembershipHistory) error
+	SaveMembershipHistory(ctx context.Context, history domain.MembershipHistory) error
 
 	GetAllCustomerIDs(ctx context.Context, page, size int) ([]string, int64, error)
 }
@@ -30,7 +30,7 @@ func NewRepository(db *gorm.DB) Repository {
 }
 
 func (r repository) GetCustomerQualifyingMiles(ctx context.Context, customerID string) (float64, error) {
-	var customer entity.Customer
+	var customer domain.Customer
 	if err := r.db.WithContext(ctx).Select("qualifying_miles_total").Where("id = ?", customerID).First(&customer).Error; err != nil {
 		return 0, err
 	}
@@ -38,21 +38,21 @@ func (r repository) GetCustomerQualifyingMiles(ctx context.Context, customerID s
 }
 
 func (r repository) UpdateCustomerMembershipTier(ctx context.Context, customerID string, memberTier string) error {
-	if err := r.db.WithContext(ctx).Model(entity.Customer{}).Update("member_tier", memberTier).Where("id = ?", customerID).Error; err != nil {
+	if err := r.db.WithContext(ctx).Model(domain.Customer{}).Update("member_tier", memberTier).Where("id = ?", customerID).Error; err != nil {
 		return err
 	}
 	return nil
 }
 
-func (r repository) GetCustomerByID(ctx context.Context, customerID string) (entity.Customer, error) {
-	var customer entity.Customer
+func (r repository) GetCustomerByID(ctx context.Context, customerID string) (domain.Customer, error) {
+	var customer domain.Customer
 	if err := r.db.WithContext(ctx).Where("id = ?", customerID).First(&customer).Error; err != nil {
-		return entity.Customer{}, err
+		return domain.Customer{}, err
 	}
 	return customer, nil
 }
 
-func (r repository) SaveMembershipHistory(ctx context.Context, history entity.MembershipHistory) error {
+func (r repository) SaveMembershipHistory(ctx context.Context, history domain.MembershipHistory) error {
 	return r.db.WithContext(ctx).Save(&history).Error
 }
 
@@ -61,14 +61,14 @@ func (r repository) GetAllCustomerIDs(ctx context.Context, page, size int) ([]st
 	var total int64
 
 	// Get total count
-	if err := r.db.WithContext(ctx).Model(&entity.Customer{}).Count(&total).Error; err != nil {
+	if err := r.db.WithContext(ctx).Model(&domain.Customer{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
 	// Get paginated customer IDs
 	offset := (page - 1) * size
 	err := r.db.WithContext(ctx).
-		Model(&entity.Customer{}).
+		Model(&domain.Customer{}).
 		Select("id").
 		Offset(offset).
 		Limit(size).

--- a/api/internal/services/customer/service.go
+++ b/api/internal/services/customer/service.go
@@ -4,14 +4,14 @@ import (
 	"context"
 
 	"github.com/erwin-lovecraft/aegismiles/internal/constants"
-	"github.com/erwin-lovecraft/aegismiles/internal/entity"
+	"github.com/erwin-lovecraft/aegismiles/internal/core/domain"
 	"github.com/erwin-lovecraft/aegismiles/internal/gateway/auth0"
 	"github.com/erwin-lovecraft/aegismiles/internal/repository"
 	"github.com/google/uuid"
 )
 
 type Service interface {
-	GetCustomer(ctx context.Context, userID string) (entity.Customer, error)
+	GetCustomer(ctx context.Context, userID string) (domain.Customer, error)
 }
 
 type service struct {
@@ -26,16 +26,16 @@ func New(repo repository.Repository, authGwy auth0.Client) Service {
 	}
 }
 
-func (s service) GetCustomer(ctx context.Context, userID string) (entity.Customer, error) {
+func (s service) GetCustomer(ctx context.Context, userID string) (domain.Customer, error) {
 	customer, err := s.repo.Customer().GetByUserID(ctx, userID)
 	if err != nil {
-		return entity.Customer{}, err
+		return domain.Customer{}, err
 	}
 
 	if customer.ID == uuid.Nil {
 		data, err := s.auth0Svc.GetUser(ctx, userID)
 		if err != nil {
-			return entity.Customer{}, err
+			return domain.Customer{}, err
 		}
 
 		customer.QualifyingMilesTotal = 0
@@ -48,7 +48,7 @@ func (s service) GetCustomer(ctx context.Context, userID string) (entity.Custome
 		customer.LastName = data.FamilyName
 
 		if err := s.repo.Customer().Save(ctx, customer); err != nil {
-			return entity.Customer{}, err
+			return domain.Customer{}, err
 		}
 	}
 

--- a/api/internal/services/customer/v2service.go
+++ b/api/internal/services/customer/v2service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/erwin-lovecraft/aegismiles/internal/config"
-	"github.com/erwin-lovecraft/aegismiles/internal/entity"
+	"github.com/erwin-lovecraft/aegismiles/internal/core/domain"
 	"github.com/erwin-lovecraft/aegismiles/internal/gateway/auth0"
 	"github.com/erwin-lovecraft/aegismiles/internal/gateway/sessionm"
 	"github.com/erwin-lovecraft/aegismiles/internal/models/dto"
@@ -28,16 +28,16 @@ func NewV2(cfg config.SessionMConfig, repo repository.Repository, authGwy auth0.
 	}
 }
 
-func (s v2service) GetCustomer(ctx context.Context, userID string) (entity.Customer, error) {
+func (s v2service) GetCustomer(ctx context.Context, userID string) (domain.Customer, error) {
 	customer, err := s.sessionmSvc.GetUser(ctx, userID)
 	if err != nil {
-		return entity.Customer{}, err
+		return domain.Customer{}, err
 	}
 
 	if customer.ID == uuid.Nil {
 		auth0Data, err := s.auth0Svc.GetUser(ctx, userID)
 		if err != nil {
-			return entity.Customer{}, err
+			return domain.Customer{}, err
 		}
 
 		sessionMRequest := dto.SessionMCreateUserRequest{
@@ -63,13 +63,13 @@ func (s v2service) GetCustomer(ctx context.Context, userID string) (entity.Custo
 
 		customer, err = s.sessionmSvc.CreateUser(ctx, sessionMRequest)
 		if err != nil {
-			return entity.Customer{}, err
+			return domain.Customer{}, err
 		}
 	}
 
 	rs := convertCustomerEntity(s.cfg, customer)
 	if err := s.repo.Customer().Save(ctx, rs); err != nil {
-		return entity.Customer{}, err
+		return domain.Customer{}, err
 	}
 
 	return rs, nil
@@ -91,8 +91,8 @@ func convertMemberTier(tier string) string {
 	return "register"
 }
 
-func convertCustomerEntity(cfg config.SessionMConfig, customer dto.SessionMUserProfile) entity.Customer {
-	rs := entity.Customer{
+func convertCustomerEntity(cfg config.SessionMConfig, customer dto.SessionMUserProfile) domain.Customer {
+	rs := domain.Customer{
 		ID:                   customer.ID,
 		QualifyingMilesTotal: customer.TierPoints,
 		BonusMilesTotal:      customer.TestPoints,

--- a/api/internal/services/mileage/v2service.go
+++ b/api/internal/services/mileage/v2service.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/erwin-lovecraft/aegismiles/internal/config"
 	"github.com/erwin-lovecraft/aegismiles/internal/constants"
-	"github.com/erwin-lovecraft/aegismiles/internal/entity"
+	"github.com/erwin-lovecraft/aegismiles/internal/core/domain"
 	"github.com/erwin-lovecraft/aegismiles/internal/gateway/sessionm"
 	"github.com/erwin-lovecraft/aegismiles/internal/models/dto"
 	"github.com/erwin-lovecraft/aegismiles/internal/repository"
@@ -86,7 +86,7 @@ func (s serviceV2) ApproveAccrualRequest(ctx context.Context, reqID string) erro
 	earningMonth := time.Date(existedRequest.DepartureDate.Year(), existedRequest.DepartureDate.Month(), 1, 0, 0, 0, 0, existedRequest.DepartureDate.Location())
 	expiresAt := earningMonth.AddDate(0, 13, 0)
 
-	if err := s.repo.Mileage().SaveMileageLedger(ctx, entity.MilesLedger{
+	if err := s.repo.Mileage().SaveMileageLedger(ctx, domain.MilesLedger{
 		CustomerID:           existedRequest.CustomerID,
 		QualifyingMilesDelta: existedRequest.QualifyingMiles,
 		BonusMilesDelta:      existedRequest.BonusMiles,


### PR DESCRIPTION
## Summary
- move entity structs to internal/core/domain and rename package to domain
- update imports to use new internal/core/domain path
- refresh swagger docs to reference domain definitions

## Testing
- `go test ./internal/... | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b47df7c2388322b8d723a5c0d32a16